### PR TITLE
fix(build): Move ng2-webstorage and angular2-cookies to dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,10 @@
     "url": "https://github.com/stormpath/stormpath-sdk-angular/issues"
   },
   "homepage": "https://github.com/stormpath/stormpath-sdk-angular#readme",
+  "dependencies": {
+    "ng2-webstorage": "1.4.3",
+    "angular2-cookie": "^1.2.6"
+  },
   "devDependencies": {
     "@angular/common": "^2.4.0",
     "@angular/compiler": "^2.4.0",
@@ -110,9 +114,7 @@
     "@angular/core": "^2.0.0",
     "@angular/forms": "^2.0.0",
     "@angular/http": "^2.0.0",
-    "rxjs": "^5.0.2",
-    "ng2-webstorage": "1.4.3",
-    "angular2-cookie": "^1.2.6"
+    "rxjs": "^5.0.2"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Since they're required and all.

Fixes #62.